### PR TITLE
ONBUILD environment.yml

### DIFF
--- a/appendix
+++ b/appendix
@@ -1,5 +1,7 @@
 USER root
 
+ENV CONDA_ENV=${CONDA_DEFAULT_ENV}
+
 # Install R, RStudio via Rocker scripts
 ENV R_VERSION="4.4.1"
 ENV R_DOCKERFILE="verse_${R_VERSION}"

--- a/appendix
+++ b/appendix
@@ -1,7 +1,5 @@
 USER root
 
-ENV CONDA_ENV=${CONDA_DEFAULT_ENV}
-
 # Install R, RStudio via Rocker scripts
 ENV R_VERSION="4.4.1"
 ENV R_DOCKERFILE="verse_${R_VERSION}"
@@ -49,6 +47,9 @@ ONBUILD RUN if [ -d ${REPO_DIR}/childimage/Desktop ]; then \
     fi
 
 # Add the environment
+# hard code conda_env for now. In the final image conda_default_env is notebook but in build context it is /srv/conda/envs/
+# some kind of start change?
+ONBUILD ENV CONDA_ENV=notebook
 ONBUILD RUN echo "Checking for 'conda-lock.yml' or 'environment.yml'..." \
         ; cd "${REPO_DIR}/childimage/" \
         ; [ -d binder ] && cd binder \

--- a/appendix
+++ b/appendix
@@ -47,23 +47,23 @@ ONBUILD RUN if [ -d ${REPO_DIR}/childimage/Desktop ]; then \
     fi
 
 # Add the environment
-ONBUILD RUN echo "Checking for 'conda-lock.yml' or 'environment.yml'..." && \
-        cd "${REPO_DIR}/childimage/" && \
-        [ -d binder ] && cd binder && \
-        [ -d .binder ] && cd .binder && \
-        if test -f "conda-lock.yml"; then 
-          echo "Using conda-lock.yml" && \
-          conda-lock install --name ${CONDA_ENV}; 
-        elif test -f "environment.yml"; then 
-          echo "Using environment.yml" && \
-          mamba env create --name ${CONDA_ENV} -f environment.yml; 
-        fi && \
-        mamba clean -yaf && \
-        find ${CONDA_DIR} -follow -type f -name '*.a' -delete && \
-        find ${CONDA_DIR} -follow -type f -name '*.js.map' -delete && \
-        if ls ${NB_PYTHON_PREFIX}/lib/python*/site-packages/bokeh/server/static > /dev/null 2>&1; then \
-          find ${NB_PYTHON_PREFIX}/lib/python*/site-packages/bokeh/server/static -follow -type f -name '*.js' ! -name '*.min.js' -delete; \
-        fi
+ONBUILD RUN echo "Checking for 'conda-lock.yml' or 'environment.yml'..." \
+        ; cd "${REPO_DIR}/childimage/" \
+        ; [ -d binder ] && cd binder \
+        ; [ -d .binder ] && cd .binder \
+        ; if test -f "conda-lock.yml" ; then echo "Using conda-lock.yml" & \
+        conda-lock install --name ${CONDA_ENV} \
+        ; elif test -f "environment.yml" ; then echo "Using environment.yml" & \
+        mamba env create --name ${CONDA_ENV} -f environment.yml  \
+        ; else echo "No conda-lock.yml or environment.yml! *creating default env*" ; \
+        mamba create --name ${CONDA_ENV} pangeo-notebook \
+        ; fi \
+        && mamba clean -yaf \
+        && find ${CONDA_DIR} -follow -type f -name '*.a' -delete \
+        && find ${CONDA_DIR} -follow -type f -name '*.js.map' -delete \
+        ; if ls ${NB_PYTHON_PREFIX}/lib/python*/site-packages/bokeh/server/static > /dev/null 2>&1; then \
+        find ${NB_PYTHON_PREFIX}/lib/python*/site-packages/bokeh/server/static -follow -type f -name '*.js' ! -name '*.min.js' -delete \
+        ; fi
 
 # Revert to default user and home as pwd
 USER ${NB_USER}

--- a/appendix
+++ b/appendix
@@ -1,5 +1,8 @@
 USER root
 
+# repo2docker does not set this; name is vague. This is the default env in repo2docker type images
+ENV CONDA_ENV=notebook
+
 # Install R, RStudio via Rocker scripts
 ENV R_VERSION="4.4.1"
 ENV R_DOCKERFILE="verse_${R_VERSION}"
@@ -47,9 +50,6 @@ ONBUILD RUN if [ -d ${REPO_DIR}/childimage/Desktop ]; then \
     fi
 
 # Add the environment
-# hard code conda_env for now. In the final image conda_default_env is notebook but in build context it is /srv/conda/envs/
-# some kind of start change?
-ONBUILD ENV CONDA_ENV=notebook
 ONBUILD RUN echo "Checking for 'conda-lock.yml' or 'environment.yml'..." \
         ; cd "${REPO_DIR}/childimage/" \
         ; [ -d binder ] && cd binder \

--- a/appendix
+++ b/appendix
@@ -33,13 +33,37 @@ RUN rm -rf ${REPO_DIR}/book ${REPO_DIR}/docs
 # Convert NB_USER to ENV (from ARG) so that it passes to the child dockerfile
 ENV NB_USER=${NB_USER}
 
+## ONBUILD section. These are run in child Dockerfiles. First thing that is run
+
+ONBUILD USER ${NB_USER}
+
 # ${REPO_DIR} is owned by ${NB_USER}
 ONBUILD COPY --chown=${NB_USER}:${NB_USER} . ${REPO_DIR}/childimage
+
 # Copy Desktop files into ${REPO_DIR}/Desktop if they exist. start will copy to Application dir and Desktop
 ONBUILD RUN if [ -d ${REPO_DIR}/childimage/Desktop ]; then \
         mkdir -p ${REPO_DIR}/Desktop && \
         cp -r ${REPO_DIR}/childimage/Desktop/* ${REPO_DIR}/Desktop/; \
     fi
+
+# Add the environment
+ONBUILD RUN echo "Checking for 'conda-lock.yml' or 'environment.yml'..." && \
+        cd "${REPO_DIR}/childimage/" && \
+        [ -d binder ] && cd binder && \
+        [ -d .binder ] && cd .binder && \
+        if test -f "conda-lock.yml"; then 
+          echo "Using conda-lock.yml" && \
+          conda-lock install --name ${CONDA_ENV}; 
+        elif test -f "environment.yml"; then 
+          echo "Using environment.yml" && \
+          mamba env create --name ${CONDA_ENV} -f environment.yml; 
+        fi && \
+        mamba clean -yaf && \
+        find ${CONDA_DIR} -follow -type f -name '*.a' -delete && \
+        find ${CONDA_DIR} -follow -type f -name '*.js.map' -delete && \
+        if ls ${NB_PYTHON_PREFIX}/lib/python*/site-packages/bokeh/server/static > /dev/null 2>&1; then \
+          find ${NB_PYTHON_PREFIX}/lib/python*/site-packages/bokeh/server/static -follow -type f -name '*.js' ! -name '*.min.js' -delete; \
+        fi
 
 # Revert to default user and home as pwd
 USER ${NB_USER}


### PR DESCRIPTION
## Working on the ONBUILD behavior

This PR is related to getting environment.yml in child repo to work. Also fixed bug related to desktop and one that would stop R package installation.

* add ONBUILD code to detect environment.yml
* add pip install jupyter desktop so it doesn't get wiped out
* fix the various ENV that were not getting propogated to child
    - NB_USER
    - CONDA_ENV
    - NB_USER in staff group (needed for rocker env permissions)