### PR TITLE
fix problem with texlive installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ ENV REPO_DIR="/srv/repo" \
 ARG R_VERSION_PULL="4.4.2"
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
-ENV PROJ_LIB=/srv/conda/envs/notebook/share/proj
     
 # Add NB_USER to staff group (required for rocker script)
 # Ensure the staff group exists first

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,15 +40,15 @@ RUN /pyrocket_scripts/install-conda-packages.sh ${REPO_DIR}/environment.yml
 # Install R, RStudio via Rocker scripts. Requires the prefix for a rocker Dockerfile
 RUN R_VERSION_PULL=$R_VERSION_PULL /pyrocket_scripts/install-rocker.sh "verse_${R_VERSION}"
 
+# Install Zotero; must be run before apt since zotero apt install requires this is run first
+RUN wget -qO- https://raw.githubusercontent.com/retorquere/zotero-deb/master/install.sh | bash 
+
 # Install extra apt packages
 # Install linux packages after R installation since the R install scripts get rid of packages
 RUN /pyrocket_scripts/install-apt-packages.sh ${REPO_DIR}/apt.txt
 
 # Install some basic VS Code extensions
 RUN /pyrocket_scripts/install-vscode-extensions.sh ${REPO_DIR}/vscode-extensions.txt
-
-# Install Zotero
-RUN wget -qO- https://raw.githubusercontent.com/retorquere/zotero-deb/master/install.sh | bash 
 
 # Re-enable man pages disabled in Ubuntu 18 minimal image
 # https://wiki.ubuntu.com/Minimal

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM ghcr.io/nmfs-opensci/py-rocket-base/base-image:latest
+
 LABEL org.opencontainers.image.maintainers="eli.holmes@noaa.gov"
 LABEL org.opencontainers.image.author="eli.holmes@noaa.gov"
 LABEL org.opencontainers.image.source=https://github.com/nmfs-opensci/py-rocket-base
-LABEL org.opencontainers.image.description="Python (3.12), R (4.4.1), Desktop and Publishing toolset"
+LABEL org.opencontainers.image.description="Python (3.12), R (4.4.1), Desktop and Publishing tools"
 LABEL org.opencontainers.image.licenses=Apache2.0
 LABEL org.opencontainers.image.version=2024.11.22
 


### PR DESCRIPTION
travis-bin.yihui.org stopped working. This was a binary of texlive install. This was used for a temp texlive install as part of install_verse.sh. Sometime after Oct 2024, the scripts were updated in master to deal with this, but new releases have not been issued. So now the code pulls from the master branch and sets the R version. This is how Rocker build images.

But not that this means the latest CRAN repo is used so would be breaking for past versions of R that would not have packages build for them.