### PR TITLE
pin code-server to 4.98.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.author="eli.holmes@noaa.gov"
 LABEL org.opencontainers.image.source=https://github.com/nmfs-opensci/py-rocket-base
 LABEL org.opencontainers.image.description="Python (3.12), R (4.4.2), Desktop and Publishing tools"
 LABEL org.opencontainers.image.licenses=Apache2.0
-LABEL org.opencontainers.image.version=2025.03.10
+LABEL org.opencontainers.image.version=2025.03.13
 
 USER root
 


### PR DESCRIPTION
and remove ms-jupyter.ai vscode extension
version to 03-13-2025

code-server was getting downgraded and this was causing a nodejs conflict or issue which gave a I2 Connector error