### PR TITLE
working on ssl error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN /pyrocket_scripts/install-conda-packages.sh ${REPO_DIR}/environment.yml
 # Be aware that if R_VERSION_PULL is set to the latest release, CRAN repo will use "latest" and date will not be pinned.
 RUN R_VERSION_PULL="master" /pyrocket_scripts/install-rocker.sh "verse_${R_VERSION}"
 
+# Set up so that users can use R in Jupyter Lab and links to ${R_HOME} and use Python in RStudio/reticulate and links to conda/envs/notebook
 # Install IRkernel and register it with Jupyter so we can select an R kernel with Jupyter Lab
 # When R is invoked, the PATH is cleaned to remove conda, but need to add conda on temporarily so that
 # installspec can find jupyter (which is in conda dir)

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,8 @@ IRkernel::installspec(name = "ir", displayname = "R ${R_VERSION}")
 EOF
 # Fix LD library path for RStudio https://github.com/rstudio/rstudio/issues/14060#issuecomment-1911329450
 RUN echo "rsession-ld-library-path=/srv/conda/envs/notebook/lib" >> /etc/rstudio/rserver.conf
+# Set default Python for reticulate
+RUN echo 'RETICULATE_PYTHON=/srv/conda/envs/notebook/bin/python' >> /etc/R/Renviron.site
 
 # Install Zotero; must be run before apt since zotero apt install requires this is run first
 RUN wget -qO- https://raw.githubusercontent.com/retorquere/zotero-deb/master/install.sh | bash 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,10 @@ RUN R_VERSION_PULL="master" /pyrocket_scripts/install-rocker.sh "verse_${R_VERSI
 RUN Rscript - <<EOF
 install.packages('IRkernel')
 Sys.setenv(PATH = paste("/srv/conda/envs/notebook/bin", Sys.getenv("PATH"), sep = ":"))
-IRkernel::installspec(name = "ir443", displayname = "R 4.4.3")
+IRkernel::installspec(name = "ir", displayname = "R ${R_VERSION}")
 EOF
+# Fix LD library path for RStudio https://github.com/rstudio/rstudio/issues/14060#issuecomment-1911329450
+RUN echo "rsession-ld-library-path=/srv/conda/envs/notebook/lib" >> /etc/rstudio/rserver.conf
 
 # Install Zotero; must be run before apt since zotero apt install requires this is run first
 RUN wget -qO- https://raw.githubusercontent.com/retorquere/zotero-deb/master/install.sh | bash 

--- a/environment.yml
+++ b/environment.yml
@@ -11,9 +11,6 @@ dependencies:
   - pip
   - jupyter-resource-usage
   - gh-scoped-creds==4.1
-  # Match the system version
-  - openssl=3.0.*
-  - libopenssl=3.0.*
 
   # R/RStudio Support
   - jupyter-rsession-proxy


### PR DESCRIPTION
* downgrading doesn't work
* only have rsession-ld-library-path in /etc/rstudio/rserver.conf. cannot be in ~/.Renviron
* set default python for reticulate