### PR TITLE
Update install-vscode-extensions.sh

### DIFF
--- a/scripts/install-vscode-extensions.sh
+++ b/scripts/install-vscode-extensions.sh
@@ -54,6 +54,11 @@ while IFS= read -r EXT; do
     fi
 done < "$ext_file"
 
+# Fix ownership so user can install/uninstall extensions later
+echo "Fixing ownership of installed extensions..."
+chown -R ${NB_USER}:${NB_USER} "${EXT_DIR}"
+chmod -R u+rwX,go+rX "${EXT_DIR}"
+
 if [ "$FAILED" -ne 0 ]; then
   echo "One or more VSCode extensions failed to install. Exiting." >&2
   exit 1

--- a/start
+++ b/start
@@ -32,4 +32,25 @@ if [ -d "${REPO_DIR}/childstart/" ]; then
         fi
     done
 fi
+
+# --- Set default VSCode code-server settings if missing ---
+DEFAULT_SETTINGS_DIR="/usr/local/share/code-server/User"
+USER_SETTINGS_DIR="/home/jovyan/.local/share/code-server/User"
+
+# Ensure User settings directory exists
+mkdir -p "${USER_SETTINGS_DIR}"
+
+if [ ! -f "${USER_SETTINGS_DIR}/settings.json" ]; then
+    echo "Creating default VSCode settings.json..."
+    cat > "${USER_SETTINGS_DIR}/settings.json" <<'EOF'
+{
+  "remote.autoForwardPorts": true,
+  "remote.autoForwardPortsSource": "process",
+  "remote.restoreForwardedPorts": false
+}
+EOF
+    chown -R jovyan:jovyan "${USER_SETTINGS_DIR}"
+else
+    echo "User already has VSCode settings.json, not overwriting."
+fi
 exec "$@"

--- a/vscode-extensions.txt
+++ b/vscode-extensions.txt
@@ -2,4 +2,3 @@ ms-python.python
 ms-toolsai.jupyter
 quarto.quarto
 anwar.papyrus-pdf
-REditorSupport.r


### PR DESCRIPTION
Remove REditorSupport.r from extensions. Seems to cause code-server to use 1Gb of RAM out of the gate.

Update start so that user setting are set so that you don't get loads of ports starting up.

Set the permissions for extensions so user can install and uninstall